### PR TITLE
Hide subtitle text on landscape phones.

### DIFF
--- a/public/assets/styles/main.css
+++ b/public/assets/styles/main.css
@@ -214,3 +214,7 @@ body {
   .section-right {
     width: 65%; } }
 
+@media (orientation: landscape) and (min-width: 500px) and (max-width: 921px) {
+  .text-subtitle {
+    display: none; } }
+

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -95,3 +95,9 @@ body {
   .section-left { display: block; }
   .section-right { width: 65%; }
 }
+
+@media (orientation: landscape) and (min-width: 500px) and (max-width: 921px){
+  .text-subtitle { 
+    display: none;
+  }
+}


### PR DESCRIPTION
To fix this:
![image](https://user-images.githubusercontent.com/1453680/85982173-47b24d80-b9dd-11ea-8154-4637927889b5.png)
